### PR TITLE
Add color placeholders

### DIFF
--- a/charmap.txt
+++ b/charmap.txt
@@ -354,6 +354,10 @@ ITA           = FD 12
 ITOITA        = FD 13
 EA            = FD 14
 
+@ Colores según género
+COLOR_PLAYER  = FD 15
+COLOR_RIVAL   = FD 16
+
 @ battle string placeholders
 
 B_BUFF1 = FD 00

--- a/gflib/string_util.c
+++ b/gflib/string_util.c
@@ -510,6 +510,21 @@ static const u8 *ExpandPlaceholder_EA(void)
         return gText_ExpandedPlaceholder_A;
 }
 
+static const u8 *ExpandPlaceholder_COLOR_PLAYER(void)
+{
+    if (gSaveBlock2Ptr->playerGender == MALE)
+        return gText_ExpandedPlaceholder_COLOR_MALE;
+    else
+        return gText_ExpandedPlaceholder_COLOR_FEMALE;
+}
+
+static const u8 *ExpandPlaceholder_COLOR_RIVAL(void)
+{
+    if (gSaveBlock2Ptr->playerGender == MALE)
+        return gText_ExpandedPlaceholder_COLOR_FEMALE;
+    else
+        return gText_ExpandedPlaceholder_COLOR_MALE;
+}
 
 static const u8 *ExpandPlaceholder_RivalName(void)
 {
@@ -583,6 +598,8 @@ const u8 *GetExpandedPlaceholder(u32 id)
         [PLACEHOLDER_ID_ITA] = ExpandPlaceholder_ITA,
         [PLACEHOLDER_ID_ITOITA] = ExpandPlaceholder_ITOITA,
         [PLACEHOLDER_ID_EA] = ExpandPlaceholder_EA,
+        [PLACEHOLDER_ID_COLOR_PLAYER] = ExpandPlaceholder_COLOR_PLAYER,
+        [PLACEHOLDER_ID_COLOR_RIVAL] = ExpandPlaceholder_COLOR_RIVAL,
         
     };
 

--- a/gflib/text.h
+++ b/gflib/text.h
@@ -271,6 +271,8 @@
 #define PLACEHOLDER_ID_ITA           0x12
 #define PLACEHOLDER_ID_ITOITA        0x13
 #define PLACEHOLDER_ID_EA            0x14
+#define PLACEHOLDER_ID_COLOR_PLAYER  0x15
+#define PLACEHOLDER_ID_COLOR_RIVAL   0x16
 
 
 // battle placeholders are located in battle_message.h

--- a/include/strings.h
+++ b/include/strings.h
@@ -26,6 +26,8 @@ extern const u8 gText_ExpandedPlaceholder_El[];
 extern const u8 gText_ExpandedPlaceholder_La[];
 extern const u8 gText_ExpandedPlaceholder_ITA[];
 extern const u8 gText_ExpandedPlaceholder_ITO[];
+extern const u8 gText_ExpandedPlaceholder_COLOR_MALE[];
+extern const u8 gText_ExpandedPlaceholder_COLOR_FEMALE[];
 
 extern const u8 gText_FromSpace[];
 

--- a/src/strings.c
+++ b/src/strings.c
@@ -26,6 +26,8 @@ const u8 gText_ExpandedPlaceholder_El[] = _("El");
 const u8 gText_ExpandedPlaceholder_La[] = _("La");
 const u8 gText_ExpandedPlaceholder_ITA[] = _("ita");
 const u8 gText_ExpandedPlaceholder_ITO[] = _("ito");
+const u8 gText_ExpandedPlaceholder_COLOR_MALE[] = _("{COLOR BLUE}");
+const u8 gText_ExpandedPlaceholder_COLOR_FEMALE[] = _("{COLOR RED}");
 
 const u8 gText_EggNickname[] = _("EGG");
 const u8 gText_Pokemon[] = _("POKéMON");


### PR DESCRIPTION
This adds placeholders ``{COLOR_PLAYER}`` and ``{COLOR_RIVAL}`` which results in a custom format depending on the gender of player.

<!--- Provide a general summary of your changes in the Title above -->

## Description

- ``{COLOR_PLAYER}`` will result in coloring the text with the color assigned to player's gender.

- ``{COLOR_RIVAL}`` will result in coloring the text with the color assigned to player's opposite gender.

Default format is ``COLOR BLUE`` for male and ``COLOR RED`` for female but this can be changed in ``src\strings.c`` by editing ``gText_ExpandedPlaceholder_COLOR_MALE`` and ``gText_ExpandedPlaceholder_COLOR_FEMALE``.

## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->
Jack Johnson#3980